### PR TITLE
Add deployment guide and improve cloud-readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,9 +56,10 @@ TOP_K=5
 # API Server Configuration
 # ==============================================
 
-# Server host and port
+# Server host and port (Cloud Run / Render override PORT at runtime)
 API_HOST=0.0.0.0
-API_PORT=8000
+API_PORT=8080
+PORT=8080
 
 # Enable debug mode
 DEBUG=False
@@ -73,8 +74,9 @@ RAW_DATA_DIR=./data/raw
 # Path to processed data
 PROCESSED_DATA_DIR=./data/processed
 
-# Path to Antigravity conversation logs
-ANTIGRAVITY_BRAIN_DIR=C:/Users/jjc29/.gemini/antigravity/brain
+# Path to Antigravity conversation logs (leave blank if unused;
+# on Windows e.g. C:/Users/<you>/.gemini/antigravity/brain)
+ANTIGRAVITY_BRAIN_DIR=
 
 # ==============================================
 # Logging Configuration

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Secrets
+.env
+.env.*
+!.env.example
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+venv/
+.venv/
+env/
+build/
+dist/
+*.egg-info/
+
+# Runtime artifacts
+logs/
+temp_audio/
+data/chroma_db/
+data/raw/
+data/processed/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,28 @@
 # Conductor Voice Agent
-# Production deployment with Gunicorn
+# Production deployment with Gunicorn on Cloud Run / Render / Docker
 
 FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install system dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy requirements
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install --no-cache-dir gunicorn
 
-# Copy application code
 COPY . .
 
-# Create necessary directories
 RUN mkdir -p temp_audio logs data/chroma_db
 
-# Expose port
-EXPOSE 8000
+ENV PORT=8080
+EXPOSE 8080
 
-# Run with Gunicorn
-CMD ["gunicorn", "api.server:app", "--bind", "0.0.0.0:8000", "--workers", "2", "--worker-class", "uvicorn.workers.UvicornWorker", "--timeout", "120"]
+# Shell form so ${PORT} is expanded at runtime (Cloud Run / Render inject PORT).
+CMD exec gunicorn api.server:app \
+    --bind 0.0.0.0:${PORT} \
+    --workers 2 \
+    --worker-class uvicorn.workers.UvicornWorker \
+    --timeout 120

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,20 @@
-# Conductor Voice Agent
-# Production deployment with Gunicorn on Cloud Run / Render / Docker
-
 FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8080
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    && rm -rf /var/lib/apt/lists/*
+# System deps (keep minimal; add build tools only if needed)
+RUN pip install --no-cache-dir --upgrade pip
 
-COPY requirements.txt .
+COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install --no-cache-dir gunicorn
 
 COPY . .
 
-RUN mkdir -p temp_audio logs data/chroma_db
-
-ENV PORT=8080
 EXPOSE 8080
 
-# Shell form so ${PORT} is expanded at runtime (Cloud Run / Render inject PORT).
-CMD exec gunicorn api.server:app \
-    --bind 0.0.0.0:${PORT} \
-    --workers 2 \
-    --worker-class uvicorn.workers.UvicornWorker \
-    --timeout 120
+# IMPORTANT: shell-form so $PORT expands on Cloud Run/Render
+CMD uvicorn api.server:app --host 0.0.0.0 --port ${PORT}

--- a/README.md
+++ b/README.md
@@ -233,6 +233,94 @@ ANTIGRAVITY_BRAIN_DIR=C:/Users/jjc29/.gemini/antigravity/brain
 - **No Telemetry**: ChromaDB telemetry disabled
 - **API Calls**: Only for embeddings (text only, no PII)
 
+## 🚀 Deploy
+
+The web/voice API in `api/server.py` runs anywhere a Python container runs. The
+recommended target is **Google Cloud Run** with the API key stored in **Secret
+Manager**. Local Docker and Render also work.
+
+### Required env vars
+
+At least one LLM provider key:
+
+| Variable | Where to get it |
+|---|---|
+| `OPENAI_API_KEY` | https://platform.openai.com/api-keys |
+| `ANTHROPIC_API_KEY` | https://console.anthropic.com/settings/keys |
+| `GOOGLE_API_KEY` | https://aistudio.google.com/app/apikey |
+
+The container binds to `0.0.0.0:${PORT}` (default `8080`). Cloud Run / Render
+inject `PORT` automatically.
+
+### Local Docker
+
+```bash
+docker build -t conductor-agent .
+docker run --rm -p 8080:8080 -e OPENAI_API_KEY=sk-... conductor-agent
+# or pass a whole .env file:
+docker run --rm -p 8080:8080 --env-file .env conductor-agent
+```
+
+Open http://localhost:8080 and check `/health` — `api_keys_configured` should be
+`true`.
+
+### Google Cloud Run (recommended)
+
+One-time setup (replace `$PROJECT_ID`):
+
+```bash
+gcloud config set project $PROJECT_ID
+gcloud services enable run.googleapis.com \
+  artifactregistry.googleapis.com \
+  secretmanager.googleapis.com
+
+# Store the key in Secret Manager
+echo -n "sk-your-openai-key" | \
+  gcloud secrets create openai-api-key --data-file=-
+
+# Grant the Cloud Run runtime SA access (project-default Compute SA)
+PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')
+gcloud secrets add-iam-policy-binding openai-api-key \
+  --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+Build + deploy:
+
+```bash
+gcloud run deploy conductor-agent \
+  --source . \
+  --region us-central1 \
+  --allow-unauthenticated \
+  --set-secrets OPENAI_API_KEY=openai-api-key:latest
+```
+
+The deploy URL appears at the end. Hit `/health` to confirm
+`api_keys_configured: true`.
+
+To rotate the key:
+
+```bash
+echo -n "sk-new-key" | \
+  gcloud secrets versions add openai-api-key --data-file=-
+gcloud run services update conductor-agent --region us-central1 \
+  --set-secrets OPENAI_API_KEY=openai-api-key:latest
+```
+
+### Render
+
+The repo includes `render.yaml`. In the Render dashboard set `OPENAI_API_KEY`
+under **Environment** — do not commit it. Render injects `PORT` automatically.
+
+### Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `502` / "service unavailable" on Cloud Run | Container didn't bind to `$PORT`. Ensure you're using the Dockerfile in this repo (shell-form `CMD`). |
+| Logs show `No LLM API key is configured` | Set `OPENAI_API_KEY` (or `--set-secrets`) and redeploy. |
+| `/api/chat` returns 500 | Check `/health` — if `api_keys_configured: false`, the key isn't reaching the container. |
+| `FileNotFoundError` for `antigravity_brain_dir` | Leave `ANTIGRAVITY_BRAIN_DIR` blank unless you actually have that folder. |
+
 ## 🚧 Future Enhancements
 
 - [x ] LangGraph conductor orchestration with specialized sub-agents

--- a/api/server.py
+++ b/api/server.py
@@ -43,12 +43,19 @@ app.add_middleware(
 conductor = None
 voice_processor = None
 
+def _is_cloud() -> bool:
+    """True on Cloud Run / Render / Railway / Heroku — skip ChromaDB."""
+    return any(
+        os.getenv(v)
+        for v in ("K_SERVICE", "RENDER", "RAILWAY", "HEROKU")
+    )
+
+
 def get_conductor():
     """Lazy initialization of conductor agent."""
     global conductor
     if conductor is None:
-        # Use minimal conductor in cloud environments (no ChromaDB)
-        is_cloud = os.getenv("RENDER") or os.getenv("RAILWAY") or os.getenv("HEROKU")
+        is_cloud = _is_cloud()
         
         try:
             if is_cloud:
@@ -122,13 +129,31 @@ async def root():
         """
 
 
+@app.on_event("startup")
+async def _startup_log_config():
+    """Log API-key configuration so missing keys are obvious in cloud logs."""
+    providers = settings.configured_providers()
+    if providers:
+        logger.info(f"Configured LLM providers: {', '.join(providers)}")
+    else:
+        logger.warning(
+            "No LLM API key configured. The /api/chat endpoint will fail "
+            "until OPENAI_API_KEY (or another provider key) is set. "
+            "See README -> Deploy."
+        )
+
+
 @app.get("/health")
 async def health_check():
     """Health check endpoint."""
+    providers = settings.configured_providers()
     return {
         "status": "healthy",
         "service": "conductor-voice-agent",
-        "version": "1.0.0"
+        "version": "1.0.0",
+        "mode": "minimal" if _is_cloud() else "full",
+        "providers": providers,
+        "api_keys_configured": bool(providers),
     }
 
 
@@ -329,7 +354,7 @@ if static_dir.exists():
 if __name__ == "__main__":
     import uvicorn
     
-    port = int(os.getenv("PORT", 8000))
+    port = int(os.getenv("PORT", 8080))
     
     logger.info(f"Starting Conductor Voice Agent on port {port}")
     

--- a/config/settings.py
+++ b/config/settings.py
@@ -43,13 +43,14 @@ class Settings(BaseSettings):
     
     # API Server
     api_host: str = "0.0.0.0"
-    api_port: int = 8000
+    api_port: int = 8080
     debug: bool = False
-    
+
     # Data Paths
     raw_data_dir: str = "./data/raw"
     processed_data_dir: str = "./data/processed"
-    antigravity_brain_dir: str = "C:/Users/jjc29/.gemini/antigravity/brain"
+    # Leave blank by default; users opt in by setting ANTIGRAVITY_BRAIN_DIR.
+    antigravity_brain_dir: str = ""
     
     # Logging
     log_level: str = "INFO"
@@ -81,6 +82,33 @@ class Settings(BaseSettings):
             self.anthropic_api_key,
             self.google_api_key
         ])
+
+    def configured_providers(self) -> list[str]:
+        """Return names of providers with a non-placeholder key set."""
+        candidates = {
+            "openai": self.openai_api_key,
+            "anthropic": self.anthropic_api_key,
+            "google": self.google_api_key,
+            "xai": self.xai_api_key,
+            "perplexity": self.perplexity_api_key,
+        }
+        return [
+            name for name, key in candidates.items()
+            if key and not key.startswith("your_")
+        ]
+
+    def require_api_key(self) -> None:
+        """Fail fast at startup with an actionable error if no key is set."""
+        if self.configured_providers():
+            return
+        raise RuntimeError(
+            "No LLM API key is configured.\n"
+            "  - Local:     copy .env.example -> .env and set OPENAI_API_KEY=sk-...\n"
+            "  - Docker:    docker run -e OPENAI_API_KEY=sk-... -p 8080:8080 <image>\n"
+            "  - Cloud Run: gcloud run deploy --set-secrets "
+            "OPENAI_API_KEY=openai-api-key:latest\n"
+            "See README.md -> Deploy."
+        )
 
 
 # Global settings instance

--- a/render.yaml
+++ b/render.yaml
@@ -1,3 +1,5 @@
+# Render config kept for reference. Preferred deploy target is Google Cloud Run
+# (see README -> Deploy). Render still works with this file.
 services:
   - type: web
     name: conductor-voice-agent
@@ -8,6 +10,11 @@ services:
     envVars:
       - key: OPENAI_API_KEY
         sync: false
+      # Optional alternates — uncomment + set in Render dashboard if used:
+      # - key: ANTHROPIC_API_KEY
+      #   sync: false
+      # - key: GOOGLE_API_KEY
+      #   sync: false
       - key: PYTHON_VERSION
         value: 3.11.0
       - key: CHROMA_PERSIST_DIR


### PR DESCRIPTION
## Summary
This PR adds comprehensive deployment documentation and refactors the codebase to be cloud-native, with better support for Google Cloud Run, Render, and local Docker deployments.

## Key Changes

**Documentation & Configuration:**
- Added extensive "Deploy" section to README with setup instructions for Google Cloud Run (recommended), local Docker, and Render
- Included troubleshooting table for common deployment issues
- Updated `.env.example` with clearer comments and corrected defaults
- Added `.gitignore` to prevent accidental secret commits
- Updated `render.yaml` with comments and optional provider keys

**Cloud Readiness:**
- Changed default `API_PORT` from 8000 → 8080 (Cloud Run standard)
- Changed default `ANTIGRAVITY_BRAIN_DIR` from hardcoded Windows path → empty string (opt-in pattern)
- Refactored Dockerfile to use shell-form `CMD` so `$PORT` env var expands correctly on Cloud Run/Render
- Removed Gunicorn in favor of direct uvicorn (simpler, works with Cloud Run's PORT injection)
- Simplified Dockerfile with minimal system dependencies

**API Server Improvements:**
- Added `_is_cloud()` helper to detect cloud environments (K_SERVICE, RENDER, RAILWAY, HEROKU)
- Added `configured_providers()` method to Settings to list active LLM providers
- Added `require_api_key()` method with actionable error messages for missing keys
- Added startup event handler that logs configured providers and warns if none are set
- Enhanced `/health` endpoint to return `mode`, `providers`, and `api_keys_configured` fields
- Changed default port in `__main__` from 8000 → 8080

## Notable Implementation Details

- The `configured_providers()` method filters out placeholder keys (starting with "your_") to avoid false positives
- Cloud detection is environment-variable based rather than hardcoded, supporting multiple platforms
- Error messages in `require_api_key()` are platform-specific (local, Docker, Cloud Run) to guide users
- Dockerfile uses shell-form CMD (`CMD uvicorn ...`) instead of exec-form to allow `$PORT` expansion—critical for Cloud Run compatibility

https://claude.ai/code/session_011s2cguGTkW6iUBd2m2gjUH