### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,2 @@
-# Conductor Voice Agent
-# Production deployment with Gunicorn
 
-FROM python:3.11-slim
-
-WORKDIR /app
-
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy requirements
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install --no-cache-dir gunicorn
-
-# Copy application code
-COPY . .
-
-# Create necessary directories
-RUN mkdir -p temp_audio logs data/chroma_db
-
-# Expose port
-EXPOSE 8000
-
-# Run with Gunicorn
-CMD ["gunicorn", "api.server:app", "--bind", "0.0.0.0:8000", "--workers", "2", "--worker-class", "uvicorn.workers.UvicornWorker", "--timeout", "120"]
+CMD gunicorn api.server:app --bind 0.0.0.0:${PORT:-8080} --workers 2 --worker-class uvicorn.workers.UvicornWorker --timeout 120


### PR DESCRIPTION
Closed as obsolete. This one-commit port/entrypoint patch was superseded by the later Cloud Run implementation and the currently healthy deployed Council service. It should not be merged into the current codebase.