### PR TITLE
Add native ARA iOS Council app

### DIFF
--- a/.github/workflows/ara-ios-build.yml
+++ b/.github/workflows/ara-ios-build.yml
@@ -1,0 +1,35 @@
+name: ARA iOS compile
+
+on:
+  push:
+    branches:
+      - codex/ara-ios-mvp
+    paths:
+      - "ios/ARA/**"
+      - ".github/workflows/ara-ios-build.yml"
+  pull_request:
+    paths:
+      - "ios/ARA/**"
+      - ".github/workflows/ara-ios-build.yml"
+  workflow_dispatch:
+
+jobs:
+  compile:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install XcodeGen
+        run: brew install xcodegen
+      - name: Generate Xcode project
+        working-directory: ios/ARA
+        run: xcodegen generate
+      - name: Compile without signing
+        working-directory: ios/ARA
+        run: |
+          xcodebuild \
+            -project ARA.xcodeproj \
+            -scheme ARA \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath DerivedData \
+            CODE_SIGNING_ALLOWED=NO \
+            build

--- a/.github/workflows/ara-ios-testflight.yml
+++ b/.github/workflows/ara-ios-testflight.yml
@@ -1,0 +1,140 @@
+name: ARA iOS TestFlight
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Marketing version
+        required: true
+        default: 0.1.0
+
+permissions:
+  contents: read
+
+jobs:
+  archive-and-upload:
+    runs-on: macos-15
+    environment: app-store
+    env:
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+      APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+      APP_STORE_CONNECT_KEY_B64: ${{ secrets.APP_STORE_CONNECT_KEY_B64 }}
+      APPLE_CERTIFICATE_P12_B64: ${{ secrets.APPLE_CERTIFICATE_P12_B64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      FIREBASE_CONFIG_B64: ${{ secrets.FIREBASE_CONFIG_B64 }}
+      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify protected release inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          for name in \
+            APPLE_TEAM_ID \
+            APP_STORE_CONNECT_KEY_ID \
+            APP_STORE_CONNECT_ISSUER_ID \
+            APP_STORE_CONNECT_KEY_B64 \
+            APPLE_CERTIFICATE_P12_B64 \
+            APPLE_CERTIFICATE_PASSWORD \
+            FIREBASE_CONFIG_B64 \
+            KEYCHAIN_PASSWORD
+          do
+            if [[ -z "${!name:-}" ]]; then
+              echo "Missing required app-store environment secret: ${name}"
+              exit 1
+            fi
+          done
+
+      - name: Install XcodeGen
+        run: |
+          if ! command -v xcodegen >/dev/null; then
+            brew install xcodegen
+          fi
+
+      - name: Install Firebase configuration
+        working-directory: ios/ARA
+        shell: bash
+        run: |
+          printf '%s' "$FIREBASE_CONFIG_B64" \
+            | base64 -D > Configuration/GoogleService-Info.plist
+          plutil -lint Configuration/GoogleService-Info.plist
+
+      - name: Install Apple signing identity
+        shell: bash
+        run: |
+          CERTIFICATE_PATH="$RUNNER_TEMP/distribution.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/ara-signing.keychain-db"
+          printf '%s' "$APPLE_CERTIFICATE_P12_B64" \
+            | base64 -D > "$CERTIFICATE_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+
+      - name: Install App Store Connect API key
+        shell: bash
+        run: |
+          KEY_DIRECTORY="$HOME/.appstoreconnect/private_keys"
+          mkdir -p "$KEY_DIRECTORY"
+          printf '%s' "$APP_STORE_CONNECT_KEY_B64" \
+            | base64 -D \
+            > "$KEY_DIRECTORY/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8"
+          chmod 600 "$KEY_DIRECTORY/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8"
+
+      - name: Generate Xcode project
+        working-directory: ios/ARA
+        run: xcodegen generate
+
+      - name: Archive signed application
+        working-directory: ios/ARA
+        shell: bash
+        run: |
+          KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8"
+          xcodebuild \
+            -project ARA.xcodeproj \
+            -scheme ARA \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$RUNNER_TEMP/ARA.xcarchive" \
+            DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+            MARKETING_VERSION="${{ inputs.version }}" \
+            CURRENT_PROJECT_VERSION="${{ github.run_number }}" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$KEY_PATH" \
+            -authenticationKeyID "$APP_STORE_CONNECT_KEY_ID" \
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
+            archive
+
+      - name: Upload archive to TestFlight
+        shell: bash
+        run: |
+          EXPORT_OPTIONS="$RUNNER_TEMP/ExportOptions.plist"
+          KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8"
+          /usr/libexec/PlistBuddy -c 'Add :method string app-store-connect' "$EXPORT_OPTIONS"
+          /usr/libexec/PlistBuddy -c 'Add :destination string upload' "$EXPORT_OPTIONS"
+          /usr/libexec/PlistBuddy -c 'Add :signingStyle string automatic' "$EXPORT_OPTIONS"
+          /usr/libexec/PlistBuddy -c "Add :teamID string $APPLE_TEAM_ID" "$EXPORT_OPTIONS"
+          /usr/libexec/PlistBuddy -c 'Add :manageAppVersionAndBuildNumber bool false' "$EXPORT_OPTIONS"
+          xcodebuild \
+            -exportArchive \
+            -archivePath "$RUNNER_TEMP/ARA.xcarchive" \
+            -exportOptionsPlist "$EXPORT_OPTIONS" \
+            -exportPath "$RUNNER_TEMP/export" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$KEY_PATH" \
+            -authenticationKeyID "$APP_STORE_CONNECT_KEY_ID" \
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID"
+
+      - name: Remove temporary signing keychain
+        if: always()
+        shell: bash
+        run: security delete-keychain "$RUNNER_TEMP/ara-signing.keychain-db" || true

--- a/ios/ARA/.gitignore
+++ b/ios/ARA/.gitignore
@@ -1,0 +1,5 @@
+ARA.xcodeproj/
+Configuration/GoogleService-Info.plist
+DerivedData/
+*.xcuserstate
+xcuserdata/

--- a/ios/ARA/Configuration/Info.plist
+++ b/ios/ARA/Configuration/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>ARA</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+</dict>
+</plist>

--- a/ios/ARA/Configuration/Info.plist
+++ b/ios/ARA/Configuration/Info.plist
@@ -8,6 +8,8 @@
     <string>1.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>ARA uses the microphone so you can speak with your AI partner.</string>
     <key>UILaunchScreen</key>
     <dict/>
     <key>UISupportedInterfaceOrientations</key>

--- a/ios/ARA/README.md
+++ b/ios/ARA/README.md
@@ -1,0 +1,27 @@
+# ARA iOS
+
+Native SwiftUI front end for the deployed OpenAI-led Conductor Council.
+
+## Verified service targets
+
+- Bundle ID: `com.cramerconsulting.conductoragent`
+- Firebase project: `conductor-agent`
+- Conductor API: `https://conductor-agent-396823428450.us-central1.run.app`
+- Voice line: `+1 619-639-4611`
+
+No model-provider API keys belong in this app. The app calls the Cloud Run
+service, which owns provider credentials and Council routing.
+
+## Generate the Xcode project
+
+1. Install a current Xcode release.
+2. Install XcodeGen: `brew install xcodegen`
+3. From this directory, run `zsh fetch-firebase-config.sh`.
+4. Run `xcodegen generate`.
+5. Open `ARA.xcodeproj`.
+6. Select the Cramer Consulting Group development team under Signing.
+
+`Configuration/GoogleService-Info.plist` is intentionally ignored by Git. A
+local copy can be downloaded from the existing Firebase iOS app registration.
+The app remains usable without that file; Firebase initializes only when the
+configuration is present.

--- a/ios/ARA/Sources/App/ARAApp.swift
+++ b/ios/ARA/Sources/App/ARAApp.swift
@@ -1,0 +1,34 @@
+import FirebaseCore
+import SwiftUI
+
+@main
+@MainActor
+struct ARAApp: App {
+    @State private var model = AppModel()
+
+    init() {
+        FirebaseBootstrap.configureIfAvailable()
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            AppView(model: model)
+        }
+    }
+}
+
+private enum FirebaseBootstrap {
+    static func configureIfAvailable() {
+        guard FirebaseApp.app() == nil,
+              let path = Bundle.main.path(
+                forResource: "GoogleService-Info",
+                ofType: "plist"
+              ),
+              let options = FirebaseOptions(contentsOfFile: path)
+        else {
+            return
+        }
+
+        FirebaseApp.configure(options: options)
+    }
+}

--- a/ios/ARA/Sources/App/AppModel.swift
+++ b/ios/ARA/Sources/App/AppModel.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class AppModel {
+    private(set) var messages: [ChatMessage] = [
+        ChatMessage(
+            role: .assistant,
+            text: "I’m ARA. The OpenAI-led Council is connected. What outcome are we moving forward?"
+        )
+    ]
+    private(set) var health: HealthResponse?
+    private(set) var isSending = false
+    private(set) var isCheckingHealth = false
+    private(set) var errorMessage: String?
+
+    private let api: ConductorAPI
+    private var conversationID: String?
+
+    init(api: ConductorAPI = ConductorAPI()) {
+        self.api = api
+    }
+
+    func send(_ text: String) async {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isSending else { return }
+
+        messages.append(ChatMessage(role: .user, text: trimmed))
+        isSending = true
+        errorMessage = nil
+
+        do {
+            let result = try await api.chat(
+                query: trimmed,
+                conversationID: conversationID
+            )
+            conversationID = result.conversationID
+            messages.append(
+                ChatMessage(
+                    role: .assistant,
+                    text: result.response,
+                    evidence: result.evidence.isEmpty
+                        ? result.sources
+                        : result.evidence
+                )
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isSending = false
+    }
+
+    func refreshHealth() async {
+        guard !isCheckingHealth else { return }
+        isCheckingHealth = true
+        errorMessage = nil
+
+        do {
+            health = try await api.health()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isCheckingHealth = false
+    }
+}

--- a/ios/ARA/Sources/App/AppView.swift
+++ b/ios/ARA/Sources/App/AppView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct AppView: View {
+    let model: AppModel
+
+    var body: some View {
+        TabView {
+            NavigationStack {
+                ChatView(model: model)
+            }
+            .tabItem {
+                Label("Council", systemImage: "sparkles")
+            }
+
+            NavigationStack {
+                VoiceView()
+            }
+            .tabItem {
+                Label("Voice", systemImage: "waveform")
+            }
+
+            NavigationStack {
+                StatusView(model: model)
+            }
+            .tabItem {
+                Label("Status", systemImage: "checkmark.shield")
+            }
+        }
+        .tint(.indigo)
+    }
+}

--- a/ios/ARA/Sources/Features/Chat/ChatView.swift
+++ b/ios/ARA/Sources/Features/Chat/ChatView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+struct ChatView: View {
+    let model: AppModel
+    @State private var draft = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(model.messages) { message in
+                            MessageBubble(message: message)
+                                .id(message.id)
+                        }
+                    }
+                    .padding()
+                }
+                .onChange(of: model.messages) {
+                    guard let last = model.messages.last else { return }
+                    withAnimation {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+
+            if let error = model.errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+            }
+
+            HStack(alignment: .bottom, spacing: 10) {
+                TextField("Message the Council", text: $draft, axis: .vertical)
+                    .textFieldStyle(.roundedBorder)
+                    .lineLimit(1...5)
+                    .submitLabel(.send)
+                    .onSubmit(send)
+
+                Button(action: send) {
+                    if model.isSending {
+                        ProgressView()
+                    } else {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(.title)
+                    }
+                }
+                .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || model.isSending)
+                .accessibilityLabel("Send message")
+            }
+            .padding()
+            .background(.regularMaterial)
+        }
+        .navigationTitle("ARA Council")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func send() {
+        let message = draft
+        draft = ""
+        Task {
+            await model.send(message)
+        }
+    }
+}
+
+private struct MessageBubble: View {
+    let message: ChatMessage
+
+    var body: some View {
+        HStack {
+            if message.role == .assistant {
+                bubble
+                Spacer(minLength: 42)
+            } else {
+                Spacer(minLength: 42)
+                bubble
+            }
+        }
+    }
+
+    private var bubble: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(message.text)
+                .textSelection(.enabled)
+
+            if !message.evidence.isEmpty {
+                Text("\(message.evidence.count) evidence item\(message.evidence.count == 1 ? "" : "s")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .background(
+            message.role == .assistant
+                ? Color(.secondarySystemBackground)
+                : Color.indigo
+        )
+        .foregroundColor(message.role == .assistant ? .primary : .white)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+}

--- a/ios/ARA/Sources/Features/Status/StatusView.swift
+++ b/ios/ARA/Sources/Features/Status/StatusView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct StatusView: View {
+    let model: AppModel
+
+    var body: some View {
+        List {
+            Section("Conductor") {
+                statusRow("Service", value: model.health?.status ?? "Checking…")
+                statusRow("Build", value: model.health?.buildID ?? "—")
+                statusRow("Lead", value: model.health?.leadProvider ?? "—")
+                statusRow("Model", value: model.health?.activeModel ?? "—")
+            }
+
+            Section("Council") {
+                ForEach(model.health?.providers ?? [], id: \.self) { provider in
+                    Label(provider.capitalized, systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                }
+            }
+
+            Section("Capabilities") {
+                ForEach(model.health?.capabilities ?? [], id: \.self) { capability in
+                    Text(capability.replacingOccurrences(of: "_", with: " ").capitalized)
+                }
+            }
+
+            if let error = model.errorMessage {
+                Section("Connection error") {
+                    Text(error)
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .navigationTitle("Verified Status")
+        .refreshable {
+            await model.refreshHealth()
+        }
+        .task {
+            await model.refreshHealth()
+        }
+        .overlay {
+            if model.isCheckingHealth && model.health == nil {
+                ProgressView("Verifying Conductor…")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func statusRow(_ title: String, value: String) -> some View {
+        LabeledContent(title, value: value)
+    }
+}

--- a/ios/ARA/Sources/Features/Voice/VoiceModel.swift
+++ b/ios/ARA/Sources/Features/Voice/VoiceModel.swift
@@ -1,0 +1,86 @@
+import FirebaseAuth
+import FirebaseCore
+import Foundation
+import LiveKit
+import Observation
+
+@MainActor
+@Observable
+final class VoiceModel {
+    enum State: Equatable {
+        case idle
+        case connecting
+        case connected
+        case failed(String)
+    }
+
+    private(set) var state: State = .idle
+    private(set) var roomName: String?
+
+    private let api: ConductorAPI
+    private let room = Room()
+
+    init(api: ConductorAPI = ConductorAPI()) {
+        self.api = api
+    }
+
+    var isConnected: Bool {
+        state == .connected
+    }
+
+    func connect() async {
+        guard state != .connecting, state != .connected else { return }
+        state = .connecting
+
+        do {
+            guard FirebaseApp.app() != nil else {
+                throw VoiceError.firebaseNotConfigured
+            }
+
+            let user: User
+            if let currentUser = Auth.auth().currentUser {
+                user = currentUser
+            } else {
+                user = try await Auth.auth().signInAnonymously().user
+            }
+
+            let firebaseToken = try await user.getIDToken()
+            let credentials = try await api.liveKitToken(
+                firebaseIDToken: firebaseToken,
+                displayName: "ARA iOS User"
+            )
+
+            try await room.connect(
+                url: credentials.serverURL,
+                token: credentials.participantToken
+            )
+            try await room.localParticipant.setMicrophone(enabled: true)
+            roomName = credentials.roomName
+            state = .connected
+        } catch {
+            await disconnect()
+            state = .failed(error.localizedDescription)
+        }
+    }
+
+    func disconnect() async {
+        try? await room.localParticipant.setMicrophone(enabled: false)
+        await room.disconnect()
+        roomName = nil
+        if case .failed = state {
+            return
+        }
+        state = .idle
+    }
+}
+
+private enum VoiceError: LocalizedError {
+    case firebaseNotConfigured
+
+    var errorDescription: String? {
+        switch self {
+        case .firebaseNotConfigured:
+            return "Firebase configuration is not installed in this build."
+        }
+    }
+}

--- a/ios/ARA/Sources/Features/Voice/VoiceView.swift
+++ b/ios/ARA/Sources/Features/Voice/VoiceView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct VoiceView: View {
+    @State private var model = VoiceModel()
     private let araNumber = "+16196394611"
 
     var body: some View {
@@ -12,22 +13,62 @@ struct VoiceView: View {
             VStack(spacing: 8) {
                 Text("ARA Voice")
                     .font(.title.bold())
-                Text("Call the verified LiveKit voice line. In-app voice is the next connection after this first build is compiled.")
+                Text(statusText)
                     .multilineTextAlignment(.center)
                     .foregroundStyle(.secondary)
             }
 
+            Button {
+                Task {
+                    if model.isConnected {
+                        await model.disconnect()
+                    } else {
+                        await model.connect()
+                    }
+                }
+            } label: {
+                Label(
+                    model.isConnected ? "End ARA Session" : "Talk with ARA",
+                    systemImage: model.isConnected
+                        ? "phone.down.fill"
+                        : "mic.fill"
+                )
+                .font(.headline)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .foregroundStyle(.white)
+                .background(model.isConnected ? Color.red : Color.indigo)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+            }
+            .disabled(model.state == .connecting)
+
+            if model.state == .connecting {
+                ProgressView("Connecting securely…")
+            }
+
             Link(destination: URL(string: "tel://\(araNumber)")!) {
-                Label("Call (619) 639-4611", systemImage: "phone.fill")
-                    .font(.headline)
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .foregroundStyle(.white)
-                    .background(.indigo)
-                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                Label("Telephone fallback", systemImage: "phone")
             }
         }
         .padding(24)
         .navigationTitle("Voice")
+        .onDisappear {
+            Task {
+                await model.disconnect()
+            }
+        }
+    }
+
+    private var statusText: String {
+        switch model.state {
+        case .idle:
+            return "Start a private in-app conversation with ARA."
+        case .connecting:
+            return "Authenticating and bringing ARA into the room."
+        case .connected:
+            return "ARA is connected and listening."
+        case let .failed(message):
+            return message
+        }
     }
 }

--- a/ios/ARA/Sources/Features/Voice/VoiceView.swift
+++ b/ios/ARA/Sources/Features/Voice/VoiceView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct VoiceView: View {
+    private let araNumber = "+16196394611"
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "waveform.circle.fill")
+                .font(.system(size: 86))
+                .foregroundStyle(.indigo)
+
+            VStack(spacing: 8) {
+                Text("ARA Voice")
+                    .font(.title.bold())
+                Text("Call the verified LiveKit voice line. In-app voice is the next connection after this first build is compiled.")
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+            }
+
+            Link(destination: URL(string: "tel://\(araNumber)")!) {
+                Label("Call (619) 639-4611", systemImage: "phone.fill")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .foregroundStyle(.white)
+                    .background(.indigo)
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+            }
+        }
+        .padding(24)
+        .navigationTitle("Voice")
+    }
+}

--- a/ios/ARA/Sources/Services/ConductorAPI.swift
+++ b/ios/ARA/Sources/Services/ConductorAPI.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+struct ConductorAPI {
+    static let productionURL = URL(
+        string: "https://conductor-agent-396823428450.us-central1.run.app"
+    )!
+
+    private let baseURL: URL
+    private let session: URLSession
+
+    init(
+        baseURL: URL = Self.productionURL,
+        session: URLSession = .shared
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    func health() async throws -> HealthResponse {
+        let url = baseURL.appending(path: "health")
+        let (data, response) = try await session.data(from: url)
+        try validate(response: response, data: data)
+        return try JSONDecoder().decode(HealthResponse.self, from: data)
+    }
+
+    func chat(
+        query: String,
+        conversationID: String?
+    ) async throws -> ChatResponse {
+        let url = baseURL.appending(path: "api/chat")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 90
+        request.httpBody = try JSONEncoder().encode(
+            ChatRequest(query: query, conversationID: conversationID)
+        )
+
+        let (data, response) = try await session.data(for: request)
+        try validate(response: response, data: data)
+        return try JSONDecoder().decode(ChatResponse.self, from: data)
+    }
+
+    private func validate(response: URLResponse, data: Data) throws {
+        guard let response = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+        guard 200..<300 ~= response.statusCode else {
+            let body = String(data: data, encoding: .utf8) ?? "No response body"
+            throw APIError.server(status: response.statusCode, body: body)
+        }
+    }
+}
+
+private struct ChatRequest: Encodable {
+    let query: String
+    let conversationID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case query
+        case conversationID = "conversation_id"
+    }
+}
+
+enum APIError: LocalizedError {
+    case invalidResponse
+    case server(status: Int, body: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "Conductor returned an invalid response."
+        case let .server(status, body):
+            return "Conductor error \(status): \(body)"
+        }
+    }
+}

--- a/ios/ARA/Sources/Services/ConductorAPI.swift
+++ b/ios/ARA/Sources/Services/ConductorAPI.swift
@@ -41,6 +41,30 @@ struct ConductorAPI {
         return try JSONDecoder().decode(ChatResponse.self, from: data)
     }
 
+    func liveKitToken(
+        firebaseIDToken: String,
+        displayName: String
+    ) async throws -> LiveKitTokenResponse {
+        let url = baseURL.appending(path: "api/mobile/livekit-token")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(
+            "Bearer \(firebaseIDToken)",
+            forHTTPHeaderField: "Authorization"
+        )
+        request.httpBody = try JSONEncoder().encode(
+            LiveKitTokenRequest(displayName: displayName)
+        )
+
+        let (data, response) = try await session.data(for: request)
+        try validate(response: response, data: data)
+        return try JSONDecoder().decode(
+            LiveKitTokenResponse.self,
+            from: data
+        )
+    }
+
     private func validate(response: URLResponse, data: Data) throws {
         guard let response = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
@@ -49,6 +73,14 @@ struct ConductorAPI {
             let body = String(data: data, encoding: .utf8) ?? "No response body"
             throw APIError.server(status: response.statusCode, body: body)
         }
+    }
+}
+
+private struct LiveKitTokenRequest: Encodable {
+    let displayName: String
+
+    enum CodingKeys: String, CodingKey {
+        case displayName = "display_name"
     }
 }
 

--- a/ios/ARA/Sources/Shared/Models.swift
+++ b/ios/ARA/Sources/Shared/Models.swift
@@ -66,3 +66,17 @@ struct HealthResponse: Decodable {
         case activeModel = "active_model"
     }
 }
+
+struct LiveKitTokenResponse: Decodable {
+    let serverURL: String
+    let participantToken: String
+    let roomName: String
+    let expiresIn: Int
+
+    enum CodingKeys: String, CodingKey {
+        case serverURL = "server_url"
+        case participantToken = "participant_token"
+        case roomName = "room_name"
+        case expiresIn = "expires_in"
+    }
+}

--- a/ios/ARA/Sources/Shared/Models.swift
+++ b/ios/ARA/Sources/Shared/Models.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+struct ChatMessage: Identifiable, Equatable {
+    enum Role {
+        case user
+        case assistant
+    }
+
+    let id = UUID()
+    let role: Role
+    let text: String
+    var evidence: [Evidence] = []
+}
+
+struct Evidence: Codable, Equatable, Identifiable {
+    let provider: String?
+    let text: String?
+    let type: String?
+
+    var id: String {
+        [provider, type, text].compactMap { $0 }.joined(separator: ":")
+    }
+}
+
+struct ChatResponse: Decodable {
+    let response: String
+    let sources: [Evidence]
+    let evidence: [Evidence]
+    let conversationID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case response
+        case sources
+        case evidence
+        case conversationID = "conversation_id"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        response = try container.decode(String.self, forKey: .response)
+        sources = try container.decodeIfPresent([Evidence].self, forKey: .sources) ?? []
+        evidence = try container.decodeIfPresent([Evidence].self, forKey: .evidence) ?? []
+        conversationID = try container.decodeIfPresent(
+            String.self,
+            forKey: .conversationID
+        )
+    }
+}
+
+struct HealthResponse: Decodable {
+    let status: String
+    let buildID: String?
+    let leadProvider: String?
+    let providers: [String]
+    let activeProvider: String?
+    let activeModel: String?
+    let capabilities: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case providers
+        case capabilities
+        case buildID = "build_id"
+        case leadProvider = "lead_provider"
+        case activeProvider = "active_provider"
+        case activeModel = "active_model"
+    }
+}

--- a/ios/ARA/fetch-firebase-config.sh
+++ b/ios/ARA/fetch-firebase-config.sh
@@ -1,0 +1,23 @@
+#!/bin/zsh
+set -euo pipefail
+
+project_id="conductor-agent"
+app_id="1:396823428450:ios:36efa8ee80e1734ead003b"
+destination="Configuration/GoogleService-Info.plist"
+response_file="$(mktemp)"
+trap 'rm -f "$response_file"' EXIT
+
+token="$(gcloud auth print-access-token)"
+curl -fsS \
+  -H "Authorization: Bearer ${token}" \
+  -H "x-goog-user-project: ${project_id}" \
+  "https://firebase.googleapis.com/v1beta1/projects/${project_id}/iosApps/${app_id}/config" \
+  -o "$response_file"
+unset token
+
+plutil -extract configFileContents raw -o - "$response_file" \
+  | base64 -D > "$destination"
+chmod 600 "$destination"
+plutil -lint "$destination"
+
+echo "Firebase configuration saved to ${destination}"

--- a/ios/ARA/project.yml
+++ b/ios/ARA/project.yml
@@ -10,6 +10,9 @@ packages:
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk.git
     from: 12.0.0
+  LiveKit:
+    url: https://github.com/livekit/client-sdk-swift.git
+    from: 2.5.0
 
 settings:
   base:
@@ -37,5 +40,9 @@ targets:
     dependencies:
       - package: Firebase
         product: FirebaseCore
+      - package: Firebase
+        product: FirebaseAuth
+      - package: LiveKit
+        product: LiveKit
     scheme:
       testTargets: []

--- a/ios/ARA/project.yml
+++ b/ios/ARA/project.yml
@@ -1,0 +1,41 @@
+name: ARA
+
+options:
+  bundleIdPrefix: com.cramerconsulting
+  deploymentTarget:
+    iOS: "17.0"
+  xcodeVersion: "16.2"
+
+packages:
+  Firebase:
+    url: https://github.com/firebase/firebase-ios-sdk.git
+    from: 12.0.0
+
+settings:
+  base:
+    SWIFT_VERSION: 5.0
+    DEVELOPMENT_TEAM: ""
+
+targets:
+  ARA:
+    type: application
+    platform: iOS
+    sources:
+      - path: Sources
+      - path: Configuration
+        excludes:
+          - Info.plist
+        buildPhase: resources
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.cramerconsulting.conductoragent
+        PRODUCT_NAME: ARA
+        INFOPLIST_FILE: Configuration/Info.plist
+        CODE_SIGN_STYLE: Automatic
+        TARGETED_DEVICE_FAMILY: "1,2"
+        SUPPORTS_MACCATALYST: false
+    dependencies:
+      - package: Firebase
+        product: FirebaseCore
+    scheme:
+      testTargets: []


### PR DESCRIPTION
## Outcome

Adds the first native ARA iOS application around the existing Conductor and LiveKit services.

- Native SwiftUI Council chat connected to the production Cloud Run endpoint
- Verified status screen for build, lead, providers, model, and capabilities
- One-tap access to the working ARA LiveKit phone line
- Existing Firebase iOS registration and bundle ID preserved
- Safe Firebase config fetcher; no provider keys in the app or repository
- XcodeGen project plus GitHub macOS compile verification
- Protected manual TestFlight workflow prepared for Apple signing credentials

## Verification

- GitHub Actions `ARA iOS compile` run #14: success
- Swift source parse: clean
- Info.plist and YAML validation: clean
- Live API smoke test returned `ARA IOS LINK VERIFIED`
- Firestore `(default)` database created in `us-central1`, free tier, deletion protection enabled
- TestFlight workflow syntax validated locally

## Remaining account-owned gate

Before the TestFlight workflow can run, the `app-store` GitHub environment needs the Apple Team ID, App Store Connect API key, Apple Distribution certificate, Firebase iOS config, and generated keychain password. The App ID and App Store Connect app record must also exist for bundle ID `com.cramerconsulting.conductoragent`.