### PR TITLE
Connect ARA iOS to secure in-app LiveKit voice

### DIFF
--- a/ios/ARA/Configuration/Info.plist
+++ b/ios/ARA/Configuration/Info.plist
@@ -8,6 +8,8 @@
     <string>1.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>ARA uses the microphone so you can speak with your AI partner.</string>
     <key>UILaunchScreen</key>
     <dict/>
     <key>UISupportedInterfaceOrientations</key>

--- a/ios/ARA/Sources/Features/Voice/VoiceModel.swift
+++ b/ios/ARA/Sources/Features/Voice/VoiceModel.swift
@@ -1,0 +1,86 @@
+import FirebaseAuth
+import FirebaseCore
+import Foundation
+import LiveKit
+import Observation
+
+@MainActor
+@Observable
+final class VoiceModel {
+    enum State: Equatable {
+        case idle
+        case connecting
+        case connected
+        case failed(String)
+    }
+
+    private(set) var state: State = .idle
+    private(set) var roomName: String?
+
+    private let api: ConductorAPI
+    private let room = Room()
+
+    init(api: ConductorAPI = ConductorAPI()) {
+        self.api = api
+    }
+
+    var isConnected: Bool {
+        state == .connected
+    }
+
+    func connect() async {
+        guard state != .connecting, state != .connected else { return }
+        state = .connecting
+
+        do {
+            guard FirebaseApp.app() != nil else {
+                throw VoiceError.firebaseNotConfigured
+            }
+
+            let user: User
+            if let currentUser = Auth.auth().currentUser {
+                user = currentUser
+            } else {
+                user = try await Auth.auth().signInAnonymously().user
+            }
+
+            let firebaseToken = try await user.getIDToken()
+            let credentials = try await api.liveKitToken(
+                firebaseIDToken: firebaseToken,
+                displayName: "ARA iOS User"
+            )
+
+            try await room.connect(
+                url: credentials.serverURL,
+                token: credentials.participantToken
+            )
+            try await room.localParticipant.setMicrophone(enabled: true)
+            roomName = credentials.roomName
+            state = .connected
+        } catch {
+            await disconnect()
+            state = .failed(error.localizedDescription)
+        }
+    }
+
+    func disconnect() async {
+        try? await room.localParticipant.setMicrophone(enabled: false)
+        await room.disconnect()
+        roomName = nil
+        if case .failed = state {
+            return
+        }
+        state = .idle
+    }
+}
+
+private enum VoiceError: LocalizedError {
+    case firebaseNotConfigured
+
+    var errorDescription: String? {
+        switch self {
+        case .firebaseNotConfigured:
+            return "Firebase configuration is not installed in this build."
+        }
+    }
+}

--- a/ios/ARA/Sources/Features/Voice/VoiceView.swift
+++ b/ios/ARA/Sources/Features/Voice/VoiceView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct VoiceView: View {
+    @State private var model = VoiceModel()
     private let araNumber = "+16196394611"
 
     var body: some View {
@@ -12,22 +13,62 @@ struct VoiceView: View {
             VStack(spacing: 8) {
                 Text("ARA Voice")
                     .font(.title.bold())
-                Text("Call the verified LiveKit voice line. In-app voice is the next connection after this first build is compiled.")
+                Text(statusText)
                     .multilineTextAlignment(.center)
                     .foregroundStyle(.secondary)
             }
 
+            Button {
+                Task {
+                    if model.isConnected {
+                        await model.disconnect()
+                    } else {
+                        await model.connect()
+                    }
+                }
+            } label: {
+                Label(
+                    model.isConnected ? "End ARA Session" : "Talk with ARA",
+                    systemImage: model.isConnected
+                        ? "phone.down.fill"
+                        : "mic.fill"
+                )
+                .font(.headline)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .foregroundStyle(.white)
+                .background(model.isConnected ? Color.red : Color.indigo)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+            }
+            .disabled(model.state == .connecting)
+
+            if model.state == .connecting {
+                ProgressView("Connecting securely…")
+            }
+
             Link(destination: URL(string: "tel://\(araNumber)")!) {
-                Label("Call (619) 639-4611", systemImage: "phone.fill")
-                    .font(.headline)
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .foregroundStyle(.white)
-                    .background(.indigo)
-                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                Label("Telephone fallback", systemImage: "phone")
             }
         }
         .padding(24)
         .navigationTitle("Voice")
+        .onDisappear {
+            Task {
+                await model.disconnect()
+            }
+        }
+    }
+
+    private var statusText: String {
+        switch model.state {
+        case .idle:
+            return "Start a private in-app conversation with ARA."
+        case .connecting:
+            return "Authenticating and bringing ARA into the room."
+        case .connected:
+            return "ARA is connected and listening."
+        case let .failed(message):
+            return message
+        }
     }
 }

--- a/ios/ARA/Sources/Services/ConductorAPI.swift
+++ b/ios/ARA/Sources/Services/ConductorAPI.swift
@@ -41,6 +41,30 @@ struct ConductorAPI {
         return try JSONDecoder().decode(ChatResponse.self, from: data)
     }
 
+    func liveKitToken(
+        firebaseIDToken: String,
+        displayName: String
+    ) async throws -> LiveKitTokenResponse {
+        let url = baseURL.appending(path: "api/mobile/livekit-token")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(
+            "Bearer \(firebaseIDToken)",
+            forHTTPHeaderField: "Authorization"
+        )
+        request.httpBody = try JSONEncoder().encode(
+            LiveKitTokenRequest(displayName: displayName)
+        )
+
+        let (data, response) = try await session.data(for: request)
+        try validate(response: response, data: data)
+        return try JSONDecoder().decode(
+            LiveKitTokenResponse.self,
+            from: data
+        )
+    }
+
     private func validate(response: URLResponse, data: Data) throws {
         guard let response = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
@@ -49,6 +73,14 @@ struct ConductorAPI {
             let body = String(data: data, encoding: .utf8) ?? "No response body"
             throw APIError.server(status: response.statusCode, body: body)
         }
+    }
+}
+
+private struct LiveKitTokenRequest: Encodable {
+    let displayName: String
+
+    enum CodingKeys: String, CodingKey {
+        case displayName = "display_name"
     }
 }
 

--- a/ios/ARA/Sources/Shared/Models.swift
+++ b/ios/ARA/Sources/Shared/Models.swift
@@ -66,3 +66,17 @@ struct HealthResponse: Decodable {
         case activeModel = "active_model"
     }
 }
+
+struct LiveKitTokenResponse: Decodable {
+    let serverURL: String
+    let participantToken: String
+    let roomName: String
+    let expiresIn: Int
+
+    enum CodingKeys: String, CodingKey {
+        case serverURL = "server_url"
+        case participantToken = "participant_token"
+        case roomName = "room_name"
+        case expiresIn = "expires_in"
+    }
+}

--- a/ios/ARA/project.yml
+++ b/ios/ARA/project.yml
@@ -10,6 +10,9 @@ packages:
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk.git
     from: 12.0.0
+  LiveKit:
+    url: https://github.com/livekit/client-sdk-swift.git
+    from: 2.5.0
 
 settings:
   base:
@@ -37,5 +40,9 @@ targets:
     dependencies:
       - package: Firebase
         product: FirebaseCore
+      - package: Firebase
+        product: FirebaseAuth
+      - package: LiveKit
+        product: LiveKit
     scheme:
       testTargets: []


### PR DESCRIPTION
## Outcome

Replaces the phone-only Voice screen with a secure in-app ARA session while keeping the telephone path as fallback.

- Firebase anonymous beta authentication
- Authenticated Cloud Run LiveKit token request
- Ten-minute room-scoped participant credentials
- Automatic `ara-economy` agent dispatch
- Native microphone publishing through the LiveKit Swift SDK
- Explicit connecting, connected, failure, and disconnect states
- No provider or LiveKit credentials in the app

## Backend verification

- Identity Platform initialized and anonymous beta auth enabled
- Cloud Run revision `conductor-agent-00014-lfq` serving 100% traffic
- Temporary Firebase user authenticated successfully
- LiveKit room token issued with agent dispatch
- Temporary verification user deleted
- 10 backend tests passed

The existing ARA telephone number remains available as a fallback.